### PR TITLE
feat: compare maps whether they are equal

### DIFF
--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -3,5 +3,9 @@
     <module2copyright>
       <element module="Project Files" copyright="Geert JM" />
     </module2copyright>
+    <LanguageOptions name="Go">
+      <option name="fileTypeOverride" value="3" />
+      <option name="block" value="false" />
+    </LanguageOptions>
   </settings>
 </component>

--- a/equal.go
+++ b/equal.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmap
+
+// Equal returns whether maps m1 and m2 are equal. Returns false if
+// length is not equal, key of m1 is not present in m2, or when value
+// is not equal for matching keys.
+// This is the simple case where we only allow comparable types as defined
+// by Go.
+// See this as a stricter, more specialized, but faster version of
+// `reflect.DeepEqual` (when comparing maps).
+func Equal[K, V comparable](m1, m2 map[K]V) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+
+	for k1, v1 := range m1 {
+		v2, ok := m2[k1]
+		if !ok || v1 != v2 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/equal_test.go
+++ b/equal_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmap_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golistic/xt"
+
+	"github.com/golistic/xmap"
+)
+
+func TestEqual(t *testing.T) {
+	t.Run("lengths are not equal", func(t *testing.T) {
+		m1 := map[string]int{"1": 1}
+		m2 := map[string]int{"1": 1, "2": 2}
+		xt.Assert(t, !xmap.Equal[string, int](m1, m2))
+	})
+
+	t.Run("lengths are not equal", func(t *testing.T) {
+		m1 := map[string]string{"1": "1"}
+		m2 := map[string]string{"1": "1"}
+		xt.Assert(t, xmap.Equal[string](m1, m2))
+	})
+
+	t.Run("values are not equal", func(t *testing.T) {
+		m1 := map[float64]string{1.2: "1"}
+		m2 := map[float64]string{1.2: "1123"}
+		xt.Assert(t, !xmap.Equal[float64, string](m1, m2))
+	})
+
+	t.Run("values are equal", func(t *testing.T) {
+		m1 := map[uint]string{2: "something", 1: "1123"}
+		m2 := map[uint]string{1: "1123", 2: "something"}
+		xt.Assert(t, xmap.Equal[uint, string](m1, m2))
+		xt.Assert(t, reflect.DeepEqual(m1, m2))
+	})
+
+	t.Run("cannot handle maps", func(t *testing.T) {
+		type rt map[int]string
+
+		r := rt{1: "1"}
+
+		m1 := map[string]any{
+			"1": r,
+		}
+
+		m2 := map[string]any{
+			"1": r,
+		}
+
+		xt.Panics(t, func() {
+			xmap.Equal[string, any](m1, m2)
+		})
+	})
+}
+
+func BenchmarkEqual(b *testing.B) {
+	v := strings.Repeat("a", 10)
+	m1, m2 := map[int]string{}, map[int]string{}
+
+	for i, j := 0, 100; i < 100; i, j = i+1, j-1 {
+		m1[i] = v
+		m2[j] = v
+	}
+
+	b.Run("using our Equal", func(b *testing.B) {
+		xmap.Equal[int, string](m1, m2)
+	})
+
+	b.Run("using our reflect.DeepEqual", func(b *testing.B) {
+		reflect.DeepEqual(m1, m2)
+	})
+}


### PR DESCRIPTION
We add the function `xmap.Equal` to compare two maps whether they are equal or not.

[1]: https://github.com/geertjanvdk/xkit

Resolves #1.